### PR TITLE
Fix:小説詳細にキャラが複数表示される

### DIFF
--- a/app/controllers/novels_controller.rb
+++ b/app/controllers/novels_controller.rb
@@ -1,5 +1,5 @@
 class NovelsController < ApplicationController
-  before_action :set_novel, only: [:show, :edit, :update]
+  before_action :set_novel, only: [:edit, :update]
   skip_before_action :require_login, only: [:index, :show]
 
   def index
@@ -24,6 +24,7 @@ class NovelsController < ApplicationController
   end
 
   def show
+    @novel = Novel.find(params[:id])
     @review = Review.new
     @reviews = @novel.reviews.includes(:user).order(created_at: :desc)
 
@@ -68,7 +69,7 @@ class NovelsController < ApplicationController
   def novel_params
     params.require(:novel).permit(
                   :title, :genre, :story_length, :plot, :image, :release,
-                  character_attributes: [:id, :character_role, :character_text, :_destroy]).merge(
+                  characters_attributes: [:id, :character_role, :character_text, :_destroy]).merge(
                   user_id: current_user.id)
   end
 end

--- a/app/views/novels/show.html.erb
+++ b/app/views/novels/show.html.erb
@@ -8,20 +8,22 @@
             <div class='col-md-9'>
               <h3 class="d-inline"><%= @novel.title %></h3>
               <ul class="list-inline">
-                <li class="list-inline-item">作者 <%= link_to @novel.user.name, user_path(@novel.user.id) %></li>
-                <li class="list-inline-item">作成日 <%= l @novel.created_at, format: :long %></li>
+                <li class="list-inline-item">作者：<%= link_to @novel.user.name, user_path(@novel.user.id) %></li>
+                <li class="list-inline-item">作成日：<%= l @novel.created_at, format: :long %></li>
               </ul>
               <ul class="list-inline">
-                <li class="list-inline-item">ジャンル <%= @novel.genre %></li>
-                <li class="list-inline-item">分類 <%= @novel.story_length %></li>
+                <li class="list-inline-item">ジャンル：<%= @novel.genre %></li>
+                <li class="list-inline-item">分類：<%= @novel.story_length %></li>
               </ul>
+              <h5>プロット</h5>
+              <p><%= simple_format(@novel.plot) %></p>
+              <h5>キャラクター設定</h5>
+              <% @novel.characters.each do |c| %>
+                <p><%= simple_format(c.character_role) %></p>
+                <p><%= simple_format(c.character_text) %></p>
+              <% end %>
             </div>
           </div>
-          <p><%= simple_format(@novel.plot) %></p>
-          <% @novel.characters.each do |c| %>
-            <p><%= simple_format(c.character_role) %></p>
-            <p><%= simple_format(c.character_text) %></p>
-          <% end %>
         </div>
       </article>
     </div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
## 概要

複数キャラを登録できること、複数表示されることを確認。
paginateはjsファイルがうまく動かなかったので要修正。