### PR TITLE
kaminariのajaxを変更

### DIFF
--- a/app/controllers/novels_controller.rb
+++ b/app/controllers/novels_controller.rb
@@ -4,7 +4,7 @@ class NovelsController < ApplicationController
 
   def index
     @q = Novel.ransack(params[:q])
-    @novels = @q.result(distinct: true).includes(:user).order(created_at: :desc)
+    @novels = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page])
   end
 
   def new

--- a/app/models/novel.rb
+++ b/app/models/novel.rb
@@ -8,8 +8,8 @@ class Novel < ApplicationRecord
   validates :title, length: { maximum: 50 }, uniqueness: true, presence: true
   validates :plot, length: { maximum: 5000 }, presence: true
 
-  enum genre: { high_fantasy: 0, low_fantasy: 10, classic: 20, love: 30, comedy: 40, mystery:50,
-    reincarnation: 50, speace_fantasy: 60, horror: 70 }
-  enum story_length: { long: 0, middle: 1, short: 2 }
-  enum release: { release: 0, reader: 1, writer: 2, draft: 3 }
+  enum genre: { high_fantasy: 10, low_fantasy: 20, classic: 30, love: 40, comedy: 50, mystery:60,
+    reincarnation: 70, speace_fantasy: 80, horror: 90 }
+  enum story_length: { long: 5, middle: 15, short: 25 }
+  enum release: { release: 1, reader: 2, writer: 3, draft: 4 }
 end

--- a/app/views/novels/index.html.erb
+++ b/app/views/novels/index.html.erb
@@ -19,3 +19,5 @@
     </div>
   </div>
 </div>
+
+<%= paginate @novels %>

--- a/app/views/novels/new.html.erb
+++ b/app/views/novels/new.html.erb
@@ -7,16 +7,16 @@
             <%= f.label :title %>
             <%= f.text_field :title, class: 'form-control' %>
           </div>
-          <div class="list-inline d-flex align-items-center">
-            <div class="form-group list-inline-item">
+          <div class="d-flex align-items-center">
+            <div class="form-group">
               <%= f.label :genre %>：
-              <%= f.select :genre, Novel.genres.keys.map, include_blank: 'ジャンルを選択'%><li>
+              <%= f.select :genre, Novel.genres.keys.map, include_blank: 'ジャンルを選択'%>
             </div>
-            <div class="form-group list-inline-item mx-auto">
+            <div class="form-group mx-auto">
               <%= f.label :story_length %>：
               <%= f.select :story_length, Novel.story_lengths.keys.map, include_blank: '文量を選択' %>
             </div>
-            <div class="form-group list-inline-item">
+            <div class="form-group">
               <%= f.label :release %>：
               <%= f.select :release, Novel.releases.keys.map, include_blank: '公開範囲を選択' %>
             </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,19 +23,21 @@
     </div>
     <ul class="col-md-10 offset-md-1">
       <div class="tab-wrap">
-        <input id="TAB-01" type="radio" name="TAB" class="tab-switch" checked="checked" />
         <% if current_user.role == 'writer' %>
+          <input id="TAB-01" type="radio" name="TAB" class="tab-switch" checked="checked" />
           <label class="tab-label" for="TAB-01">投稿した作品</label>
           <div class="tab-content">
             <%= render partial: 'user_novels', collection: @user_novels %>
-            <%= paginate @user_novels, id: "js-show-novels", remote: true %>
+            <%= paginate @user_novels, param_name: 'novel_page' %>
           </div>
+        <% else %>
+          投稿した作品はありません
         <% end %>
         <input id="TAB-02" type="radio" name="TAB" class="tab-switch" checked="checked" />
         <label class="tab-label" for="TAB-02">批評した作品</label>
         <div class="tab-content">
           <%= render partial: 'user_reviews', collection: @user_reviews %>
-          <%= paginate @user_reviews, id: "js-show-reviews", remote: true %>
+          <%= paginate @user_reviews, param_name: 'review_name' %>
         </div>
       </div>
     </ul>

--- a/app/views/users/show.js.erb
+++ b/app/views/users/show.js.erb
@@ -1,2 +1,2 @@
-$("#js-show-novels").html("<%= escape_javascript(render 'show_novels', object: @user_novels) %>");
-$("#js-show-reviews").html("<%= escape_javascript(render 'show_reviews', object: @user_reviews) %>");
+$("#js-show-novels").html("<%= j(render 'user_novels', { user_novels: @user_novels}) %>");
+$("#js-show-reviews").html("<%= j(render 'user_reviews') %>");

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  # config.default_per_page = 25
+  config.default_per_page = 25
   # config.max_per_page = nil
   # config.window = 4
   # config.outer_window = 0


### PR DESCRIPTION
## 概要

kaminariでajaxを行おうとしたが、NoMethodErrorが出る。
(ajaxでなければページ遷移できる)
また、ページ遷移を行うと、別タブに移動してしまう。

数日間上記の解決法を探していたが結局分からないので、別の表示方法を試す。
タブではなく要素を縦に二分して、投稿小説と批評小説を表示する予定。

ページネーション参考予定url
https://qiita.com/yuutetu/items/b83d7c634914b1e99e89
https://qiita.com/YutoYasunaga/items/370e4749281abd0bca4a
http://peta345.github.io/2016/12/05/kaminari%E3%81%A71%E3%83%9A%E3%83%BC%E3%82%B8%E5%86%85%E3%81%A7%E8%A4%87%E6%95%B0%E3%81%AEpagination%E3%82%92%E4%BD%BF%E3%81%86%E6%96%B9%E6%B3%95/