### PR TITLE
Add:トップページに直近で批評したユーザーを表示

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,8 +1,6 @@
 class StaticPagesController < ApplicationController
     skip_before_action :require_login
 
-    def top; end
-
     def rule; end
 
     def privacy; end

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,0 +1,7 @@
+class TopsController < ApplicationController
+    skip_before_action :require_login
+
+    def top
+        @reviews = Review.order(created_at: :desc).limit(1)
+    end
+end

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -1,7 +1,0 @@
-仮トップページ
-<p>テスト</p>
-<script type="text/javascript">
-  $(document).ready(function() {
-    $("p").text("成功！！");
-  });
-</script>

--- a/app/views/tops/top.html.erb
+++ b/app/views/tops/top.html.erb
@@ -1,0 +1,9 @@
+仮トップページ
+<p>テスト</p>
+
+
+<div>
+  <% @reviews.each do |review| %>
+    <p><%= review.user.name %></p>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  root 'static_pages#top'
+  root 'tops#top'
   get 'rule', to: 'static_pages#rule'
   get 'privacy', to: 'static_pages#privacy'
   


### PR DESCRIPTION
## 概要

top用コントローラーを作成、ルーティングを変更、viewの場所を変更。
直近で批評したユーザー名を表示。現在はテスト用にlimit(1)としている。
仮リリース実装時には3〜5名の予定。利用者数によって、最大10名までを検討。