### PR TITLE
Fix:actiontext実装にあたっての変更

### DIFF
--- a/app/controllers/novels_controller.rb
+++ b/app/controllers/novels_controller.rb
@@ -3,7 +3,7 @@ class NovelsController < ApplicationController
   skip_before_action :require_login, only: [:index, :show]
 
   def index
-    @q = Novel.ransack(params[:q])
+    @q = Novel.search(params["q"])
     @novels = @q.result(distinct: true).includes(:user).order(created_at: :desc).page(params[:page]).per(15)
   end
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -4,6 +4,5 @@ class Character < ApplicationRecord
   has_rich_text :character_text
 
   validates :character_text, length: { maximum: 2000 }
-  validates :character_text, length: { maximum: 2000 }
   validates :character_role, length: { maximum:20 }
 end

--- a/app/models/novel.rb
+++ b/app/models/novel.rb
@@ -8,13 +8,19 @@ class Novel < ApplicationRecord
   accepts_nested_attributes_for :characters, reject_if: :all_blank, allow_destroy: true
 
   validates :title, length: { maximum: 50 }, uniqueness: true, presence: true
-  validates :plot, length: { maximum: 5000 }, presence: true
   validates :genre, presence: true
   validates :story_length, presence: true
   validates :release, presence: true
+  validates :plot_required, length: { maximum: 7000}
 
   enum genre: { high_fantasy: 10, low_fantasy: 20, classic: 30, love: 40, love_comedy: 50,
     gag: 60, mystery:70, reincarnation: 80, speace_fantasy: 90, horror: 100 }
   enum story_length: { long: 5, middle: 15, short: 25 }
   enum release: { release: 1, reader: 2, writer: 3, draft: 4 }
+
+  private
+
+  def plot_required
+    errors.add(:plot, I18n.t('defaults.message.nill_plot')) unless plot.body.present?
+  end
 end

--- a/app/views/novels/_search.html.erb
+++ b/app/views/novels/_search.html.erb
@@ -1,10 +1,11 @@
 <%= search_form_for @q, url: url do |f| %>
     <div class="input-group mb-3">
-        <%= f.search_field :title_or_plot_cont, class:'form-control', placeholder: (t '.word') %>
+        <%= f.search_field :title_cont, class:'form-control mr-2', placeholder: (t '.title') %>
+        <%= f.search_field :user_name_cont, class:'form-control mr-2', placeholder: (t '.user_name') %>
         <%= f.select :genre_eq, Novel.genres_i18n.invert.map{|key, value| [key, Novel.genres[value]]},
-            {include_blank: (t '.genre')}, { class: 'form-control' } %>
+            {include_blank: (t '.genre')}, { class: 'form-control mr-2' } %>
         <%= f.select :story_length_eq, Novel.story_lengths_i18n.invert.map{|key, value| [key, Novel.story_lengths[value]]},
-            {include_blank: (t '.story_length')}, { class: 'form-control mr-2' } %>
+            {include_blank: (t '.story_length')}, { class: 'form-control mr-4' } %>
         <div class="input-group-append">
             <%= f.submit (t '.search'), class:'btn btn-primary' %>
         </div>

--- a/config/locales/activerecord/views/ja.yml
+++ b/config/locales/activerecord/views/ja.yml
@@ -20,6 +20,10 @@ ja:
       delete: '%{item}を削除しました'
       delete_confirm: '削除しますか？'
       not_authorized: '権限がありません'
+      nill_plot: 'プロットを入力してください'
+      over_plot: 'プロットは5000文字以内で入力してください'
+      over_profile: 'プロフィールは5000文字以内で入力してください'
+      over_character_text: 'キャラクター設定は2000文字以内で入力してください'
   users:
     new:
       topic: 'ユーザー登録'
@@ -47,7 +51,8 @@ ja:
       topic: '小説一覧'
       no_result: '該当作品がありません'
     search:
-      word: '検索ワード'
+      title: 'タイトル検索'
+      user_name: 'ユーザー名検索'
       genre: 'ジャンル検索'
       story_length: '文量検索'
       search: '検索'

--- a/db/migrate/20220404045956_remove_plot_from_novels.rb
+++ b/db/migrate/20220404045956_remove_plot_from_novels.rb
@@ -1,0 +1,7 @@
+class RemovePlotFromNovels < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :novels, :plot, :text
+    remove_column :characters, :character_text, :text
+    remove_column :users, :profile, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_03_142810) do
+ActiveRecord::Schema.define(version: 2022_04_04_045956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,7 +55,6 @@ ActiveRecord::Schema.define(version: 2022_04_03_142810) do
 
   create_table "characters", force: :cascade do |t|
     t.bigint "novel_id", null: false
-    t.text "character_text"
     t.string "character_role"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -67,7 +66,6 @@ ActiveRecord::Schema.define(version: 2022_04_03_142810) do
     t.string "title", null: false
     t.integer "genre", default: 0, null: false
     t.integer "story_length", default: 0, null: false
-    t.text "plot", null: false
     t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -93,7 +91,6 @@ ActiveRecord::Schema.define(version: 2022_04_03_142810) do
     t.string "salt"
     t.boolean "admin", default: false, null: false
     t.integer "role", default: 0, null: false
-    t.text "profile"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 概要

actiontext実装時に、モデルにカラムが必要ないことを知ったので対象のカラムを削除。
(小説投稿時にnot_null_errorが出て気づいた)
また、ransaclでplotを含む検索ができなくなったので、フリーワード(title、plot)検索をタイトル検索へ変更、ユーザー名検索を追加した。

文字数制限は厳密にはその文字数ではないので、多めにとることで対応。(htmlを含めた文字数の管理はできないので、アプリ内に注意書きが必要)


参考url
https://qiita.com/daisuke114/items/0c0b7df16c361e52dd38
https://tanaken0515.hatenablog.com/entry/2020/01/26/102533

画像に対するバリデーションは下記を参考に実装予定
https://note.com/mosanei/n/naab5937b45ee