### PR TITLE
Rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,11 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-doc'
   gem 'pry-rails'
+
+  #Rspec
+  gem 'factory_bot_rails'
+  gem 'rspec-rails'
+  gem 'simplecov', require: false
 end
 
 group :development do
@@ -82,11 +87,6 @@ group :development do
   gem 'spring-commands-rspec'
   gem 'better_errors'
   gem 'binding_of_caller'
-
-  #Rspec
-  gem 'factory_bot_rails'
-  gem 'rspec-rails'
-  gem 'simplecov', require: false
 
   #Code analyze
   gem 'brakeman', require: false

--- a/app/models/novel.rb
+++ b/app/models/novel.rb
@@ -11,7 +11,8 @@ class Novel < ApplicationRecord
   validates :genre, presence: true
   validates :story_length, presence: true
   validates :release, presence: true
-  validates :plot_required, length: { maximum: 7000}
+  validates :plot, length: { maximum: 7000}
+  validate :plot_required
 
   enum genre: { high_fantasy: 10, low_fantasy: 20, classic: 30, love: 40, love_comedy: 50,
     gag: 60, mystery:70, reincarnation: 80, speace_fantasy: 90, horror: 100 }

--- a/spec/factories/novels.rb
+++ b/spec/factories/novels.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     sequence(:title) { |n| "title-#{n}"}
     genre { :high_fantasy }
     story_length { :long }
+    plot { 'test_plot' }
     release { :release }
     association :user
 

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe Character, type: :model do
     end
 
     it 'character_role文字数超過' do
-      character_over_character_role = build(:character, character_role: "a" * 20)
+      character_over_character_role = build(:character, character_role: "a" * 21)
       expect(character_over_character_role).to be_invalid
-      expect(character_over_character_role.errors[:character_role]).to eq ["can't be over"]
+      expect(character_over_character_role.errors[:character_role]).to eq ["は20文字以内で入力してください"]
     end
 
     it 'character_text文字数超過' do
       character_over_character_text = build(:character, character_text: "a" * 3001)
       expect(character_over_character_text).to be_invalid
-      expect(character_over_character_role.errors[:character_text]).to eq ["can't be over"]
+      expect(character_over_character_text.errors[:character_text]).to eq ["は3000文字以内で入力してください"]
     end
   end
 end

--- a/spec/models/novel_spec.rb
+++ b/spec/models/novel_spec.rb
@@ -57,5 +57,11 @@ RSpec.describe Novel, type: :model do
       expect(novel_with_anoher_title).to be_valid
       expect(novel_with_anoher_title.errors).to be_empty
     end
+
+    it 'plot文字数超過' do
+      novel_over_plot = build(:novel, plot: "a" * 7001)
+      expect(novel_over_plot).to be_invalid
+      expect(novel_over_plot.errors[:plot]).to eq ["は7000文字以内で入力してください"]
+    end
   end
 end

--- a/spec/models/novel_spec.rb
+++ b/spec/models/novel_spec.rb
@@ -9,40 +9,46 @@ RSpec.describe Novel, type: :model do
     end
 
     it 'title空白' do
-      novel_without_title = build(:novel, title: nil)
+      novel_without_title = build(:novel, title: "")
       expect(novel_without_title).to be_invalid
-      expect(novel_without_title.errors[:title]).to eq["can't be blank"]
+      expect(novel_without_title.errors[:title]).to eq ["を入力してください"]
     end
 
     it 'genre空白' do
       novel_without_genre = build(:novel, genre: nil)
       expect(novel_without_genre).to be_invalid
-      expect(novel_without_genre.errors[:genre]).to eq["can't be blank"]
+      expect(novel_without_genre.errors[:genre]).to eq ["を入力してください"]
     end
 
     it 'story_length空白' do
       novel_without_story_length = build(:novel, story_length: nil)
       expect(novel_without_story_length).to be_invalid
-      expect(novel_without_story_length.errors[:story_length]).to eq["can't be blank"]
+      expect(novel_without_story_length.errors[:story_length]).to eq ["を入力してください"]
     end
 
     it 'release空白' do
       novel_without_release = build(:novel, release: nil)
       expect(novel_without_release).to be_invalid
-      expect(novel_without_release.errors[:release]).to eq["can't be blank"]
+      expect(novel_without_release.errors[:release]).to eq ["を入力してください"]
+    end
+
+    it 'plot空白' do
+      novel_without_plot = build(:novel, plot: "")
+      expect(novel_without_plot).to be_invalid
+      expect(novel_without_plot.errors[:plot]).to eq ["を入力してください"]
     end
 
     it 'title文字数超過' do
       novel_over_title = build(:novel, title: "a" * 51)
       expect(novel_over_title).to be_invalid
-      expect(novel_over_title.errors[:title]).to eq ["can't be over"]
+      expect(novel_over_title.errors[:title]).to eq ["は50文字以内で入力してください"]
     end
 
     it 'title重複' do
       novel = create(:novel)
       novel_with_duplicated_title = build(:novel, title: novel.title)
       expect(novel_with_duplicated_title).to be_invalid
-      expect(novel_with_duplicated_title.errors[:title]).to eq ["has already been taken"]
+      expect(novel_with_duplicated_title.errors[:title]).to eq ["はすでに存在します"]
     end
 
     it '別のtitle' do

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -11,19 +11,19 @@ RSpec.describe Review, type: :model do
     it 'good_point空白' do
       review_without_good_point = build(:review, good_point: nil)
       expect(review_without_good_point).to be_invalid
-      expect(review_without_good_point.errors[:good_point]).to eq["can't be blank"]
+      expect(review_without_good_point.errors[:good_point]).to eq ["を入力してください"]
     end
 
     it 'good_point文字数超過' do
       review_over_good_point = build(:review, good_point: "a" * 1501)
       expect(review_over_good_point).to be_invalid
-      expect(review_over_good_point.errors[:good_point]).to eq ["can't be over"]
+      expect(review_over_good_point.errors[:good_point]).to eq ["は1500文字以内で入力してください"]
     end
 
     it 'badd_point文字数超過' do
       review_over_bad_point = build(:review, bad_point: "a" * 1501)
       expect(review_over_bad_point).to be_invalid
-      expect(review_over_bad_point.errors[:bad_point]).to eq ["can't be over"]
+      expect(review_over_bad_point.errors[:bad_point]).to eq ["は1500文字以内で入力してください"]
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,38 +11,38 @@ RSpec.describe User, type: :model do
     it 'name空白' do
       user_without_name = build(:user, name: nil)
       expect(user_without_name).to be_invalid
-      expect(user_without_name.errors[:name]).to eq["can't be blank"]
+      expect(user_without_name.errors[:name]).to eq ["を入力してください"]
     end
 
     it 'email空白' do
       user_without_email = build(:user, email: nil)
       expect(user_without_email).to be_invalid
-      expect(user_without_email.errors[:email]).to eq ["can't be blank"]
+      expect(user_without_email.errors[:email]).to eq ["を入力してください"]
     end
 
     it 'password空白' do
       user_without_password = build(:user, password: nil)
       expect(user_without_password).to be_invalid
-      expect(user_without_password.errors[:password]).to eq ["can't be blank"]
+      expect(user_without_password.errors[:password]).to eq ["は4文字以上で入力してください"]
     end
 
     it 'password_confirmation空白' do
       user_without_password_confimation = build(:user, password_confirmation: nil)
       expect(user_without_password_confimation).to be_invalid
-      expect(user_without_password_confimation.errors[:password_confirmation]).to eq ["can't be blank"]
+      expect(user_without_password_confimation.errors[:password_confirmation]).to eq ["を入力してください"]
     end
 
     it 'name文字数超過' do
       user_over_name = build(:user, name: "a" * 31)
       expect(user_over_name).to be_invalid
-      expect(user_over_name.errors[:name]).to eq ["can't be over"]
+      expect(user_over_name.errors[:name]).to eq ["は30文字以内で入力してください"]
     end
 
     it 'email重複' do
       user = create(:user)
       user_with_duplicated_email = build(:user, email: user.email)
       expect(user_with_duplicated_email).to be_invalid
-      expect(user_with_duplicated_email.errors[email]).to eq ["has already been taken"]
+      expect(user_with_duplicated_email.errors[:email]).to eq ["はすでに存在します"]
     end
 
     it '別のemail' do
@@ -50,6 +50,12 @@ RSpec.describe User, type: :model do
       user_with_anoher_email = build(:user, email: 'another_email@example.com')
       expect(user_with_anoher_email).to be_valid
       expect(user_with_anoher_email.errors).to be_empty
+    end
+
+    it 'password3文字以下' do
+      user_few_password = build(:user, password: "aaa")
+      expect(user_few_password).to be_invalid
+      expect(user_few_password.errors[:password]).to eq ["は4文字以上で入力してください"]
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,8 +39,8 @@ RSpec.configure do |config|
   # examples within a transaction, remove the following line or assign false
   # instead of true.
   config.use_transactional_fixtures = true
+
   config.include ActionTextHelper, type: :system
-  config.include FactoryBot::Syntax::Methods
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 
@@ -63,4 +63,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## 概要

モデルスペックをタイポ記述ミス等修正。
actiontext部もfactoriesで要作成だったので、plotを追加。

plotの字数超過を追加した際、バリデーションの表記が問題でテストが通らなかったので、カスタムバリデーションと字数制限を切り分け。

gemfileのtestの位置を修正。