### PR TITLE
Fix:下書きを自分のマイページで確認できるように

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,9 @@ class UsersController < ApplicationController
   end
 
   def show
-    if @user.novels.where.not(release: 'draft') && current_user&.role == "writer"
+    if @user.id == current_user&.id
+      @narrow = @user.novels
+    elsif @user.novels.where.not(release: 'draft') && current_user&.role == "writer"
       @narrow = @user.novels.where.not(release: 'draft')
     elsif user_narrow && current_user&.role == "reader"
       @narrow = user_narrow

--- a/app/views/novels/index.html.erb
+++ b/app/views/novels/index.html.erb
@@ -13,7 +13,7 @@
         <% if @novels.present? %>
           <%= render @novels %>
         <% else %>
-          <p><%= t('.no_result') %></p>
+          <p class="text-center"><%= t('.no_result') %></p>
         <% end %>
         <%= paginate @novels %>
       </div>


### PR DESCRIPTION
## 概要

下書きがidを直打ちしないと自分でも確認できなかったので、コントローラーを修正。
また、検索結果に該当作品がない旨の文言を中央へ移動。