### PR TITLE
Fix:Admin用に使いやすく修正

### DIFF
--- a/app/views/admin/reviews/edit.html.erb
+++ b/app/views/admin/reviews/edit.html.erb
@@ -13,6 +13,10 @@
           <%= f.label :bad_point %>
           <%= f.text_area :bad_point, class: 'form-control' %>
         </div>
+        <div class="form-group">
+          <%= f.label :comment %>
+          <%= f.text_area :comment, class: 'form-control' %>
+        </div>
         <%= f.submit class: 'btn btn-primary' %>
       <% end %>
     </div>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -10,6 +10,9 @@
   <!-- Right navbar links -->
   <ul class="navbar-nav ml-auto">
     <li class="nav-item">
+      <%= link_to t('defaults.top'), root_path, class: 'nav-link' %>
+    </li>
+    <li class="nav-item">
       <%= link_to t('defaults.logout'), admin_logout_path, class: 'nav-link', method: :delete %>
     </li>
   </ul>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <aside class="main-sidebar sidebar-dark-primary elevation-4">
-  <a href="index3.html" class="brand-link">
+  <a href="/admin" class="brand-link">
     <%= image_tag 'AdminLTELogo.png', class: 'brand-image img-circle elevation-3' %>
     <span class="brand-text font-weight-light">AdminLTE 3</span>
   </a>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -40,6 +40,9 @@
               <% end %>
             </div>
             <%= link_to (t 'users.show.topic'), user_path(current_user.id), class: 'dropdown-item' %>
+            <% if current_user.admin == true %>
+              <%= link_to (t 'defaults.admin'), admin_root_path, class: 'dropdown-item' %>
+            <% end %>
             <%= link_to (t 'defaults.logout'), logout_path, class: 'dropdown-item', method: :delete %>
           </ul>
         </li>

--- a/config/locales/activerecord/views/ja.yml
+++ b/config/locales/activerecord/views/ja.yml
@@ -15,6 +15,7 @@ ja:
     notification: '通知'
     cancel: 'キャンセル'
     top: 'トップページへ'
+    admin: '管理画面'
     message:
       require_login: 'ログインしてください'
       created: "%{item}を投稿しました"


### PR DESCRIPTION
## 概要

管理画面にトップページへのリンクを追加、通常のヘッダー/ドロップダウンに管理者のみ管理画面へのリンクを追加。
管理画面／批評編集ページに返信用フォームがなかったので追加。