### PR TITLE
Add:Notificationと返信のRspec追加/他修正

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -9,6 +9,6 @@ class NotificationsController < ApplicationController
   def destroy
     @notifications = Notification.find(params[:id])
     @notifications.destroy
-    redirect_to notifications_path
+    redirect_to notifications_path, alert: t('defaults.message.delete', item: Notification.model_name.human)
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -7,5 +7,5 @@ class Review < ApplicationRecord
 
   validates :good_point, presence: true, length: { maximum: 1500 }
   validates :bad_point, length: { maximum: 1500 }
-  validates :comment, length: { maximum: 1000 }
+  validates :comment, presence: true, length: { maximum: 1000 }
 end

--- a/app/views/reviews/_edit_form.html.erb
+++ b/app/views/reviews/_edit_form.html.erb
@@ -10,6 +10,9 @@
             <%= f.label :bad_point %>
             <%= f.text_area :bad_point, class: 'form-control', id: 'js-new-review-bad_point', rows: 3 %>
           </div>
+          <div class="form-group">
+            <%= f.hidden_field :comment, class: 'form-control', value: 'Review' %>
+          </div>
 
           <div class="text-center">
             <%= link_to (t 'defaults.cancel'), novel_path(@novel), class: 'btn btn-secondary', id: 'cancel-button', local: false %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -10,6 +10,9 @@
             <%= f.label :bad_point %>
             <%= f.text_area :bad_point, class: 'form-control', id: 'js-new-review-bad_point', rows: 3 %>
           </div>
+          <div class="form-group">
+            <%= f.hidden_field :comment, class: 'form-control', value: 'Review' %>
+          </div>
 
           <div class="text-center">
             <%= f.submit class: 'btn btn-primary' %>

--- a/app/views/reviews/_reply_form.html.erb
+++ b/app/views/reviews/_reply_form.html.erb
@@ -17,7 +17,7 @@
           <li>
             <div class="text-center">
               <%= link_to (t 'defaults.cancel'), novel_path(@novel), class: 'btn btn-secondary', id: 'cancel-button', local: false %>
-              <%= f.submit class: 'btn btn-primary' %>
+              <%= f.submit name: 'reply-commit', class: 'btn btn-primary' %>
             </div>
           </li>
         <% end %>

--- a/spec/system/admin_novels_spec.rb
+++ b/spec/system/admin_novels_spec.rb
@@ -5,13 +5,12 @@ RSpec.describe "AdminNovels", type: :system do
     let!(:writer) { create(:user, :writer) }
     let(:novel) { create(:novel, user: writer) }
 
-    before
-        login(admin)
-        visit edit_admin_novels_path(novel)
+    before { login(admin) }
 
         describe '小説編集' do
             context 'フォームの入力値が正常' do
                 it '小説編集が成功する' do
+                    visit edit_admin_novels_path(novel)
                     fill_in 'タイトル', with: 'update-test-title'
                     select 'ホラー', from: 'novel_genre'
                     select '短編', from: 'novel_story_length'
@@ -25,6 +24,7 @@ RSpec.describe "AdminNovels", type: :system do
 
             context '空白' do
                 it '小説編集が失敗する' do
+                    visit edit_admin_novels_path(novel)
                     fill_in 'タイトル', with: ''
                     select 'ジャンルを選択', from: 'novel_genre'
                     select '文量を選択', from: 'novel_story_length'
@@ -42,7 +42,8 @@ RSpec.describe "AdminNovels", type: :system do
             end
 
             context '字数超過' do
-                it '小説投稿が失敗する' do
+                it '小説編種が失敗する' do
+                    visit edit_admin_novels_path(novel)
                     fill_in 'タイトル', with: 'a' * 51
                     select 'ホラー', from: 'novel_genre'
                     select '短編', from: 'novel_story_length'
@@ -57,7 +58,8 @@ RSpec.describe "AdminNovels", type: :system do
             end
 
             context 'タイトル重複' do
-                it '小説投稿が失敗する' do
+                it '小説編集が失敗する' do
+                    visit edit_admin_novels_path(novel)
                     existed_novel = create(:novel)
                     fill_in 'タイトル', with: existed_novel.title
                     select 'ハイファンタジー', from: 'novel_genre'
@@ -76,7 +78,7 @@ RSpec.describe "AdminNovels", type: :system do
             let!(:novel) { create(:novel, user: writer) }
 
             it '小説の削除ができる' do
-                visit novel_path(novel)
+                visit admin_novel_path(novel)
                 page.accept_confirm("削除しますか？") do
                     click_button '削除'
                 end

--- a/spec/system/admin_reviews_spec.rb
+++ b/spec/system/admin_reviews_spec.rb
@@ -6,14 +6,13 @@ RSpec.describe "AdminReviews", type: :system do
     let!(:novel) { create(:novel, user: admin) }
     let!(:review) { create(:review, novel: novel, user: reader) }
 
-    before
-        login(admin)
-        visit edit_admin_reviews_path(review)
+    before { login(admin) }
 
         describe '批評編集' do
 
             context 'フォームの入力値が正常' do
                 it '批評編集が成功する' do
+                    visit edit_admin_reviews_path(review)
                     fill_in '良い点', with: 'update_good'
                     fill_in '改善点', with: 'update_bad'
                     click_button '更新する'
@@ -25,6 +24,7 @@ RSpec.describe "AdminReviews", type: :system do
 
             context 'good_pointが未入力' do
                 it '批評編集が失敗する' do
+                    visit edit_admin_reviews_path(review)
                     fill_in '良い点', with: ''
                     fill_in '改善点', with: 'update_bad'
                     click_button '更新する'
@@ -35,6 +35,7 @@ RSpec.describe "AdminReviews", type: :system do
 
             context '字数制限超過' do
                 it '批評編集が失敗する' do
+                    visit edit_admin_reviews_path(review)
                     fill_in '良い点', with: 'g' * 1501
                     fill_in '改善点', with: 'b' * 1501
                     click_button '更新する'
@@ -50,6 +51,7 @@ RSpec.describe "AdminReviews", type: :system do
 
             context '入力値が正常' do
                 it '編集が成功する' do
+                    visit edit_admin_reviews_path(review)
                     fill_in '返信', with: 'update-reply'
                     click_button '更新する'
                     expect(page).to have_content '批評を更新しました'
@@ -59,6 +61,7 @@ RSpec.describe "AdminReviews", type: :system do
 
             context '字数制限超過' do
                 it '編集が失敗する' do
+                    visit edit_admin_reviews_path(review)
                     fill_in '返信', with: 'r' * 1001
                     click_button '更新する'
                     expect(page).to have_content '返信は1000文字以内で入力してください'

--- a/spec/system/admin_users_spec.rb
+++ b/spec/system/admin_users_spec.rb
@@ -4,13 +4,12 @@ RSpec.describe "AdminUsers", type: :system do
     let(:admin) { create(:user, :admin) }
     let(:reader) { create(:user, :reader) }
 
-    before 
-        login(admin)
-        visit edit_admin_user_path(reader)
+    before { login(admin) }
 
         describe 'ユーザー情報の編集' do
             context '入力値が正常' do
                 it 'ユーザー情報の編集' do
+                    visit edit_admin_user_path(reader)
                     fill_in 'ペンネーム', with: 'update-name'
                     fill_in 'メールアドレス', with: 'update@example.com'
                     select '書き手', from: 'user_role'
@@ -23,6 +22,7 @@ RSpec.describe "AdminUsers", type: :system do
 
             context '未入力' do
                 it 'ユーザーの編集が失敗する' do
+                    visit edit_admin_user_path(reader)
                     fill_in 'メールアドレス', with: ''
                     fill_in 'ペンネーム', with: ''
                     fill_in_rich_text_area 'プロフィール', with: 'update_profile'
@@ -36,6 +36,7 @@ RSpec.describe "AdminUsers", type: :system do
 
             context '登録済みのメールアドレスを使用' do
                 it 'ユーザーの編集が失敗する' do
+                    visit edit_admin_user_path(reader)
                     fill_in 'メールアドレス', with: reader.email
                     fill_in 'ペンネーム', with: 'update_name'
                     fill_in_rich_text_area 'プロフィール', with: 'update_profile'
@@ -48,6 +49,7 @@ RSpec.describe "AdminUsers", type: :system do
 
             context 'プロフィール字数超過' do
                 it 'ユーザーの編集が失敗する' do
+                    visit edit_admin_user_path(reader)
                     fill_in 'メールアドレス', with: 'update@example.com'
                     fill_in 'ペンネーム', with: 'update_name'
                     fill_in_rich_text_area 'プロフィール', with: 'a' * 5001

--- a/spec/system/notification_spec.rb
+++ b/spec/system/notification_spec.rb
@@ -2,7 +2,46 @@ require 'rails_helper'
 
 RSpec.describe "Reviews", type: :system do
     let(:user) { create(:user) }
-    let!(:novel) { create(:novel, user_id: user.id) }
-    let!(:other_user) { create(:user, :reader) }
-    let!(:review) { create(:review, novel_id: novel.id, user_id: other_user.id) }
+    let(:novel) { create(:novel, user: user) }
+    let(:other_user) { create(:user, :reader) }
+    let!(:review) { create(:review, novel: novel, user: other_user) }
+
+    describe '通知が作成される' do
+        context '自分の作品に批評がついた時' do
+            it '通知のお知らせがある' do
+                login(user)
+                unchecked_notifications.any? == true
+            end
+
+            it '通知一覧に通知がある' do
+                login(user)
+                visit notifications_path
+                expect(page).to have_content "#{other_user.name}さんが#{novel.titke}にコメントしました"
+            end
+        end
+
+        context '自分の批評に返信がついた時' do
+            let!(:reply) { create(:review, parent_id: review.id, novel: novel, user: user) }
+
+            it '通知のお知らせがある' do
+                login(other_user)
+                unchecked_notifications.any? == true
+            end
+
+            it '通知一覧に通知がある' do
+                login(other_user)
+                visit notifications_path
+                expect(page).to have_content "#{user.name}さんが#{novel.title}にコメントしました"
+            end
+        end
+    end
+
+    describe '通知の削除' do
+        it '通知の削除が成功する' do
+            visit notifications_path
+            click_link '通知を削除'
+            expect(page).to have_content '通知を削除しました'
+            expect(current_path).to eq notifications_path
+        end
+    end
 end

--- a/spec/system/reviews_spec.rb
+++ b/spec/system/reviews_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "Reviews", type: :system do
   let!(:novel) { create(:novel) }
-  let!(:other_user) { create(:user, :reader) }
+  let(:other_user) { create(:user, :reader) }
 
   describe 'ログイン後' do
     before { login(other_user) }


### PR DESCRIPTION
## 概要

Ntificationと返信のRspecを作成。
途中でcommentが空で投稿できることに気づいたため、presence: true、通常の批評投稿フォームにhidden_fieldを追加。
また、テスト作成にあたって、返信用フォームの属性を追加。