### PR TITLE
Fix:Rspec修正

### DIFF
--- a/app/views/reviews/_reply_form.html.erb
+++ b/app/views/reviews/_reply_form.html.erb
@@ -17,7 +17,7 @@
           <li>
             <div class="text-center">
               <%= link_to (t 'defaults.cancel'), novel_path(@novel), class: 'btn btn-secondary', id: 'cancel-button', local: false %>
-              <%= f.submit name: 'reply-commit', class: 'btn btn-primary' %>
+              <%= f.submit class: 'btn btn-primary reply-commit' %>
             </div>
           </li>
         <% end %>

--- a/app/views/reviews/create.js.erb
+++ b/app/views/reviews/create.js.erb
@@ -1,7 +1,7 @@
 $("#error_messages").remove()
 <% if @review.errors.present? %>
   $("#js-new-review").prepend("<%= j(render 'shared/error_messages', object: @review) %>")
-<% elsif @review.comment.blank? %>
+<% elsif @review.comment == 'Review' %>
   $("#js-table-review").prepend("<%= j(render 'reviews/review', review: @review) %>")
   $("#js-new-review-good_point").val('')
   $("#js-new-review-bad_point").val('')

--- a/app/views/reviews/edit.js.erb
+++ b/app/views/reviews/edit.js.erb
@@ -1,4 +1,4 @@
-<% if @review.comment.blank? %>
+<% if @review.comment == 'Review' %>
     $('#review-text-<%= @review.id %>').html("<%= escape_javascript(render 'reviews/edit_form', novel: @novel, review: @review) %>")
 <% else %>
     $('#js-reply-<%= @reply.id %>').html("<%= escape_javascript(render 'reviews/reply_form', review: @review) %>")

--- a/app/views/reviews/update.js.erb
+++ b/app/views/reviews/update.js.erb
@@ -1,7 +1,7 @@
 $("#error_messages").remove()
 <% if @review.errors.present? %>
   $("#js-new-review").prepend("<%= j(render 'shared/error_messages', object: @review) %>")
-<% elsif @review.comment.blank? %>
+<% elsif @review.comment == 'Review' %>
   $('#review-area').html("<%= escape_javascript(render 'reviews/reviews', reviews: @reviews) %>")
 <% else %>
   $("#js-reply-create").prepend("<%= j(render 'reviews/reply', reply: @review) %>")

--- a/spec/factories/reviews.rb
+++ b/spec/factories/reviews.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :review do
     sequence(:good_point) { |n| "good-#{n}"}
     sequence(:bad_point) { |n| "bad-#{n}"}
+    sequence(:comment) { |n| "comment-#{n}" }
     association :user
     association :novel
-    association :parent, class_name: 'Review'
 
     trait :comment do
       sequence(:good_point) { |n| "reply-#{n}" }

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Notification, type: :model do
 
       it "批評がついた際に保存できる" do
         login(:other_user)
-        notification = build(:notification, review_id: review.id, novel_id: novel.id, visited_id: novel.user_id)
+        notification = build(:notification, review: review, novel: novel, visited: novel.user_id)
         expect(notification).to be_valid
       end
     end

--- a/spec/system/admin_novels_spec.rb
+++ b/spec/system/admin_novels_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "AdminNovels", type: :system do
         describe '小説編集' do
             context 'フォームの入力値が正常' do
                 it '小説編集が成功する' do
-                    visit edit_admin_novels_path(novel)
+                    visit edit_admin_novel_path(novel)
                     fill_in 'タイトル', with: 'update-test-title'
                     select 'ホラー', from: 'novel_genre'
                     select '短編', from: 'novel_story_length'
@@ -24,17 +24,11 @@ RSpec.describe "AdminNovels", type: :system do
 
             context '空白' do
                 it '小説編集が失敗する' do
-                    visit edit_admin_novels_path(novel)
+                    visit edit_admin_novel_path(novel)
                     fill_in 'タイトル', with: ''
-                    select 'ジャンルを選択', from: 'novel_genre'
-                    select '文量を選択', from: 'novel_story_length'
-                    select '公開範囲を選択', from: 'novel_release'
-                    fill_in_rich_text_area 'プロット', with: 'u'
+                    fill_in_rich_text_area 'プロット', with: ''
                     click_button '更新する'
                     expect(page).to have_content 'タイトルを入力してください'
-                    expect(page).to have_content 'ジャンルを入力してください'
-                    expect(page).to have_content '文量を入力してください'
-                    expect(page).to have_content '公開範囲を入力してください'
                     expect(page).to have_content 'プロットを入力してください'
                     expect(page).to have_content '小説を更新できませんでした'
                     expect(current_path).to eq admin_novel_path(novel)
@@ -43,7 +37,7 @@ RSpec.describe "AdminNovels", type: :system do
 
             context '字数超過' do
                 it '小説編種が失敗する' do
-                    visit edit_admin_novels_path(novel)
+                    visit edit_admin_novel_path(novel)
                     fill_in 'タイトル', with: 'a' * 51
                     select 'ホラー', from: 'novel_genre'
                     select '短編', from: 'novel_story_length'
@@ -59,7 +53,7 @@ RSpec.describe "AdminNovels", type: :system do
 
             context 'タイトル重複' do
                 it '小説編集が失敗する' do
-                    visit edit_admin_novels_path(novel)
+                    visit edit_admin_novel_path(novel)
                     existed_novel = create(:novel)
                     fill_in 'タイトル', with: existed_novel.title
                     select 'ハイファンタジー', from: 'novel_genre'
@@ -80,7 +74,7 @@ RSpec.describe "AdminNovels", type: :system do
             it '小説の削除ができる' do
                 visit admin_novel_path(novel)
                 page.accept_confirm("削除しますか？") do
-                    click_button '削除'
+                    click_link '削除'
                 end
                 expect(page).to have_content '小説を削除しました'
                 expect(current_path).to eq admin_novels_path

--- a/spec/system/admin_reviews_spec.rb
+++ b/spec/system/admin_reviews_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "AdminReviews", type: :system do
 
             context 'フォームの入力値が正常' do
                 it '批評編集が成功する' do
-                    visit edit_admin_reviews_path(review)
+                    visit edit_admin_review_path(review)
                     fill_in '良い点', with: 'update_good'
                     fill_in '改善点', with: 'update_bad'
                     click_button '更新する'
@@ -24,24 +24,24 @@ RSpec.describe "AdminReviews", type: :system do
 
             context 'good_pointが未入力' do
                 it '批評編集が失敗する' do
-                    visit edit_admin_reviews_path(review)
+                    visit edit_admin_review_path(review)
                     fill_in '良い点', with: ''
                     fill_in '改善点', with: 'update_bad'
                     click_button '更新する'
                     expect(page).to have_content '良い点を入力してください'
-                    expect(current_path).to eq edit_admin_review_path(review)
+                    expect(current_path).to eq admin_review_path(review)
                 end
             end
 
             context '字数制限超過' do
                 it '批評編集が失敗する' do
-                    visit edit_admin_reviews_path(review)
+                    visit edit_admin_review_path(review)
                     fill_in '良い点', with: 'g' * 1501
                     fill_in '改善点', with: 'b' * 1501
                     click_button '更新する'
                     expect(page).to have_content '良い点は1500文字以内で入力してください'
                     expect(page).to have_content '改善点は1500文字以内で入力してください'
-                    expect(current_path).to eq edit_admin_review_path(review)
+                    expect(current_path).to eq admin_review_path(review)
                 end
             end
         end
@@ -51,7 +51,7 @@ RSpec.describe "AdminReviews", type: :system do
 
             context '入力値が正常' do
                 it '編集が成功する' do
-                    visit edit_admin_reviews_path(review)
+                    visit edit_admin_review_path(reply)
                     fill_in '返信', with: 'update-reply'
                     click_button '更新する'
                     expect(page).to have_content '批評を更新しました'
@@ -61,7 +61,7 @@ RSpec.describe "AdminReviews", type: :system do
 
             context '字数制限超過' do
                 it '編集が失敗する' do
-                    visit edit_admin_reviews_path(review)
+                    visit edit_admin_review_path(reply)
                     fill_in '返信', with: 'r' * 1001
                     click_button '更新する'
                     expect(page).to have_content '返信は1000文字以内で入力してください'
@@ -71,10 +71,12 @@ RSpec.describe "AdminReviews", type: :system do
         end
 
         describe '批評削除' do
+            let!(:reply) { create(:review, parent_id: review.id, novel: novel, user: admin) }
+
             it '批評の削除が成功する' do
-                visit admin_review_path(review)
+                visit admin_review_path(reply)
                 page.accept_confirm("削除しますか？") do
-                    click_button '削除'
+                    click_link '削除'
                 end
                 expect(page).to have_content '批評を削除しました'
                 expect(current_path).to eq admin_reviews_path

--- a/spec/system/admin_users_spec.rb
+++ b/spec/system/admin_users_spec.rb
@@ -36,8 +36,9 @@ RSpec.describe "AdminUsers", type: :system do
 
             context '登録済みのメールアドレスを使用' do
                 it 'ユーザーの編集が失敗する' do
+                    existed_user = create(:user)
                     visit edit_admin_user_path(reader)
-                    fill_in 'メールアドレス', with: reader.email
+                    fill_in 'メールアドレス', with: existed_user.email
                     fill_in 'ペンネーム', with: 'update_name'
                     fill_in_rich_text_area 'プロフィール', with: 'update_profile'
                     click_button '更新する'
@@ -64,9 +65,8 @@ RSpec.describe "AdminUsers", type: :system do
         describe 'ユーザー削除' do
             it 'ユーザーの削除が成功する' do
                 visit admin_user_path(reader)
-                click_button '削除'
                 page.accept_confirm("削除しますか？") do
-                    click_button '削除'
+                    click_link '削除'
                 end
                 expect(page).to have_content 'ユーザーを削除しました'
                 expect(current_path).to eq admin_users_path

--- a/spec/system/reviews_spec.rb
+++ b/spec/system/reviews_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Reviews", type: :system do
         context 'フォームの入力値が正常' do
           it '批評編集が成功する' do
             visit novel_path(novel)
-            find('.js-edit-review-button').click
+            find('.js-edit-review-button').clickgit 
             find("input[value='#{review.good_point}']").set('update_good')
             find("input[value='#{review.bad_point}']").set('update_bad')
             click_button '更新する'
@@ -107,10 +107,11 @@ RSpec.describe "Reviews", type: :system do
 
         context '入力値が正常' do
           it '返信が成功する' do
+            login(user)
             visit novel_path(novel)
             click_link '返信'
             fill_in 'review[comment]', with: 'reply'
-            find('reply-commit').click
+            find('.reply-commit').click
             expect(page).to have_content 'reply'
             expect(current_path).to eq novel_path(novel)
           end
@@ -118,10 +119,12 @@ RSpec.describe "Reviews", type: :system do
 
         context 'commentが未入力' do
           it '返信が失敗する' do
+            login(user)
             visit novel_path(novel)
+            visit current_path
             click_link '返信'
             fill_in 'review[comment]', with: ''
-            find('reply-commit').click
+            find('.reply-commit').click
             expect(page).to have_content '返信を入力してください'
             expect(current_path).to eq novel_path(novel)
           end
@@ -129,10 +132,12 @@ RSpec.describe "Reviews", type: :system do
 
         context '字数超過' do
           it '返信が失敗する' do
+            login(user)
             visit novel_path(novel)
+            visit current_path
             click_link '返信'
             fill_in 'review[comment]', with: 'a' * 1001
-            find('reply-commit').click
+            find('.reply-commit').click
             expect(page).to have_content '返信は1000文字以内で入力してください'
             expect(current_path).to eq novel_path(novel)
           end
@@ -145,10 +150,11 @@ RSpec.describe "Reviews", type: :system do
 
         context '入力値が正常' do
           it '更新が成功する' do
+            login(user)
             visit novel_path(novel)
             find('.js-edit-reply-button').click
             fill_in 'review[comment]', with: 'update-reply'
-            find('reply-commit').click
+            find('.reply-commit').click
             expect(page).to have_content 'update-reply'
             expect(current_path).to eq novel_path(novel)
           end
@@ -156,9 +162,11 @@ RSpec.describe "Reviews", type: :system do
 
         context 'commentが未入力' do
           it '返信が失敗する' do
+            login(user)
             visit novel_path(novel)
             find('.js-edit-reply-button').click
             find("input[value='#{reply.comment}']").set('')
+            find('.reply-commit').click
             expect(page).to have_content '返信を入力してください'
             expect(current_path).to eq novel_path(novel)
           end
@@ -166,9 +174,11 @@ RSpec.describe "Reviews", type: :system do
 
         context '字数超過' do
           it '返信が失敗する' do
+            login(user)
             visit novel_path(novel)
             find('.js-edit-reply-button').click
             find("input[value='#{reply.comment}']").set('r' * 1001)
+            find('.reply-commit').click
             expect(page).to have_content '返信は1000文字以内で入力してください'
             expect(current_path).to eq novel_path(novel)
           end


### PR DESCRIPTION
## 概要

作成したシステムスペックを修正。
ただしreviews_specだけ何故かボタンの反応が一部ない箇所があり、テストを通過しない。
(エラーを見るに、ボタン自体は押せている)

エラーが出るのは下記
```
1) Reviews ログイン後 批評編集 フォームの入力値が正常 批評編集が成功する
     Failure/Error: find("input[value='#{review.good_point}']").set('update_good')

     Capybara::ElementNotFound:
       Unable to find css "input[value='good-1']"


  2) Reviews ログイン後 批評編集 good_pointが未入力 批評編集が失敗する
     Failure/Error: find("input[value='#{review.good_point}']").set('')

     Capybara::ElementNotFound:
       Unable to find css "input[value='good-2']"


 3) Reviews ログイン後 批評編集 字数超過 批評編集が失敗する
     Failure/Error: find("input[value='#{review.good_point}']").set('g' * 1501)

     Capybara::ElementNotFound:
       Unable to find css "input[value='good-3']"


  4) Reviews ログイン後 返信投稿 commentが未入力 返信が失敗する
     Failure/Error: expect(page).to have_content '返信を入力してください'
       expected to find text "返信を入力してください" in "プロットホーム\n小説メニュー\nuser-9\n小説詳細\ntitle-9\n作者：user-9 作成日時：2022年 04月 26日 19時 13分\nジャンル：ハイファンタジー 文量：長編\nプロット\ntest_plot\n\nreader-9\n返信\n\n\n良い点\ngood-6\n改善点\nbad-6\nキャンセル\n\n\nプライバシーポリシー\n利用規約\nこのサイトについて\nCopyright ©︎ 2022 PlotHome"


  5) Reviews ログイン後 返信投稿 字数超過 返信が失敗する
     Failure/Error: expect(page).to have_content '返信は1000文字以内で入力してください'
       expected to find text "返信は1000文字以内で入力してください" in "プロットホーム\n小説メニュー\nuser-10\n小説詳細\ntitle-10\n作者：user-10 作成日時：2022年 04月 26日 19時 13分\nジャンル：ハイファンタジー 文量：長編\nプロット\ntest_plot\n\nreader-10\n返信\n\n\n良い点\ngood-7\n改善点\nbad-7\nキャンセル\n\n\nプライバシーポリシー\n利用規約\nこのサイトについて\nCopyright ©︎ 2022 PlotHome"


  6) Reviews ログイン後 返信編集 commentが未入力 返信が失敗する
     Failure/Error: find("input[value='#{reply.comment}']").set('')

     Capybara::ElementNotFound:
       Unable to find css "input[value='comment-11']"


  7) Reviews ログイン後 返信編集 字数超過 返信が失敗する
     Failure/Error: find("input[value='#{reply.comment}']").set('r' * 1001)

     Capybara::ElementNotFound:
       Unable to find css "input[value='comment-13']"


  8) Reviews ログイン後 返信削除 返信の削除が成功する
     Failure/Error: expect(page).not_to have_content reply.comment
       expected not to find text "comment-15" in "プロットホーム\n小説メニュー\nuser-14\n小説詳細\ntitle-14\n作者：user-14 作成日時：2022年 04月 26日 19時 13分\nジャンル：ハイファンタジー 文量：長編\nプロット\ntest_plot\n\nreader-14\n返信\n\n\n良い点\ngood-14\n改善点\nbad-14\nuser-14\ncomment-15\n\n\nプライバシーポリシー\n利用規約\nこのサイトについて\nCopyright ©︎ 2022 PlotHome"
```


1〜3は編集ボタン押下後のajaxによる編集フォーム表示ができていない。
4〜5はフォームは表示され、入力もされるが、投稿されない。
6〜7は、フォームは表示されるが、指定した内容を特定・変更できていない。fill_in 'review[comment]'〜に変えれば特定・変更できるが投稿はされない。
9はボタン押下は通るが、削除できていない。


以前動いていた箇所も動かなくなっている。
一部は正常に動作する + どれも実際の操作では問題なく動くので、いまいち原因がわからない。