### PR TITLE
Fix:Rspec完了

### DIFF
--- a/app/views/reviews/create.js.erb
+++ b/app/views/reviews/create.js.erb
@@ -1,6 +1,7 @@
 $("#error_messages").remove()
 <% if @review.errors.present? %>
   $("#js-new-review").prepend("<%= j(render 'shared/error_messages', object: @review) %>")
+  $("#js-new-reply").prepend("<%= j(render 'shared/error_messages', object: @review) %>")
 <% elsif @review.comment == 'Review' %>
   $("#js-table-review").prepend("<%= j(render 'reviews/review', review: @review) %>")
   $("#js-new-review-good_point").val('')

--- a/app/views/reviews/update.js.erb
+++ b/app/views/reviews/update.js.erb
@@ -1,6 +1,7 @@
 $("#error_messages").remove()
 <% if @review.errors.present? %>
   $("#js-new-review").prepend("<%= j(render 'shared/error_messages', object: @review) %>")
+  $("#js-new-reply").prepend("<%= j(render 'shared/error_messages', object: @review) %>")
 <% elsif @review.comment == 'Review' %>
   $('#review-area').html("<%= escape_javascript(render 'reviews/reviews', reviews: @reviews) %>")
 <% else %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -20,6 +20,9 @@ ja:
         plot: 'プロット'
         image: '添付画像'
         release: '公開範囲'
+      novel/characters:
+        character_role: '役割'
+        character_text: '設定'
       character:
         character_role: '役割'
         character_text: '設定'

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -3,16 +3,12 @@ require 'rails_helper'
 RSpec.describe Notification, type: :model do
   describe "通知" do
     context "review関連の通知" do
-      before do
-        user = create(:user)
-        other_user = create(:user, :reader)
-        novel = create(:novel)
-        review = create(:review)
-      end
-
       it "批評がついた際に保存できる" do
-        login(:other_user)
-        notification = build(:notification, review: review, novel: novel, visited: novel.user_id)
+        user = create(:user)
+        novel = create(:novel, user: user)
+        other_user = create(:user, :reader)
+        review = create(:review, user: other_user)
+        notification = build(:notification, review: review, novel: novel, visitor_id: other_user.id, visited_id: user.id)
         expect(notification).to be_valid
       end
     end

--- a/spec/system/characters_spec.rb
+++ b/spec/system/characters_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe "Characters", type: :system do
   describe 'ログイン後' do
     before { login(novel.user) }
 
-    #スクロールできれば通ると思われる
       describe 'キャラクター追加' do
         context 'フォームの入力値が正常' do
           it 'キャラクターの追加が成功する' do
@@ -14,24 +13,23 @@ RSpec.describe "Characters", type: :system do
             find('.add_fields').click
             fill_in '役割', with: 'test_role'
             fill_in_rich_text_area '設定', with: 'test_text'
-            execute_script('window.scrollBy(0,10000)')
-            find(:xpath, '//*[@id="novel-post"]').hover.click
+            find(:id, 'novel-post').send_keys :tab
+            click_button('更新する')
             expect(page).to have_content '小説を更新しました'
             expect(current_path).to eq novel_path(novel)
           end
         end
 
-        #スクロールできれば通ると思われる
         context '字数超過' do
           it 'キャラクターの追加が失敗する' do
             visit edit_novel_path(novel)
             find('.add_fields').click
             fill_in '役割', with: 'a' * 21
-            fill_in_rich_text_area '設定', with: 'a' * 3001
-            execute_script('window.scrollBy(0,10000)')
-            find(:xpath, '//*[@id="novel-post"]').hover.click
+            fill_in_rich_text_area '設定', with: 'a' * 5001
+            find(:id, 'novel-post').send_keys :tab
+            click_button('更新する')
             expect(page).to have_content '役割は20文字以内で入力してください'
-            expect(page).to have_content '設定は3000文字以内で入力してください'
+            expect(page).to have_content '設定は5000文字以内で入力してください'
             expect(current_path).to eq novel_path(novel)
           end
         end
@@ -48,7 +46,7 @@ RSpec.describe "Characters", type: :system do
           end
           expect(page).not_to have_content character.character_role
           expect(page).not_to have_content character.character_text
-          expect(current_path).to eq novel_path(novel)
+          expect(current_path).to eq edit_novel_path(novel)
         end
       end
   end

--- a/spec/system/reviews_spec.rb
+++ b/spec/system/reviews_spec.rb
@@ -121,7 +121,6 @@ RSpec.describe "Reviews", type: :system do
           end
         end
 
-        #上にスクロールできれば通ると思われる
         context 'commentが未入力' do
           it '返信が失敗する' do
             login(user)
@@ -135,7 +134,6 @@ RSpec.describe "Reviews", type: :system do
           end
         end
 
-        #上にスクロールできれば通ると思われる
         context '字数超過' do
           it '返信が失敗する' do
             login(user)
@@ -166,7 +164,6 @@ RSpec.describe "Reviews", type: :system do
           end
         end
 
-        #上にスクロールできれば通ると思われる
         context 'commentが未入力' do
           it '返信が失敗する' do
             login(user)
@@ -174,13 +171,11 @@ RSpec.describe "Reviews", type: :system do
             find('.js-edit-reply-button').click
             fill_in 'review[comment]', with: ''
             find('.reply-commit').click
-            execute_script('window.scroll(10000,0)')
             expect(page).to have_content '返信を入力してください'
             expect(current_path).to eq novel_path(novel)
           end
         end
 
-        #上にスクロールできれば通ると思われる
         context '字数超過' do
           it '返信が失敗する' do
             login(user)
@@ -188,7 +183,6 @@ RSpec.describe "Reviews", type: :system do
             find('.js-edit-reply-button').click
             fill_in 'review[comment]', with: 'a' * 1001
             find('.reply-commit').click
-            execute_script('window.scroll(10000,0)')
             expect(page).to have_content '返信は1000文字以内で入力してください'
             expect(current_path).to eq novel_path(novel)
           end


### PR DESCRIPTION
## 概要

Rspec作成完了

characters_specは更新ボタンの選択方法を変えると通るようになった。
また、バリデーションエラー時のi18nが効いていなかったので追記。
cocoonでのi18nの設定方法は下記を参考に。
参考url
https://k-koh.hatenablog.com/entry/2020/06/27/125710

reviews_specの返信失敗は、スクロールの問題ではなく、エラーメッセージがそもそも表示されていなかったのが問題だった。
createとupdateのjsファイルに返信時にもエラーメッセージが表示されるよう修正。