### PR TITLE
Fix:批評の抽出要件を修正

### DIFF
--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -3,7 +3,7 @@ class TopsController < ApplicationController
 
     def top
         #最近批評した人を抽出
-        @reviews = Review.select(:user_id).where(comment: nil, id: Review.select("DISTINCT ON (user_id) id").order(:user_id, id: :desc)).order(id: :desc).limit(3)
+        @reviews = Review.select(:user_id).where(comment: 'Review', id: Review.select("DISTINCT ON (user_id) id").order(:user_id, id: :desc)).order(id: :desc).limit(3)
 
         #最近投稿された作品を振り分け
         @novels_post = Novel.where.not(release: 'draft').order(created_at: :desc)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,7 +30,7 @@ class UsersController < ApplicationController
     @user_novels = @narrow.order(created_at: :desc).page(params[:novel_page]).per(4)
 
     #批評した作品に表示する作品を抽出
-    @reviews = Review.from(Review.where(comment: nil, user_id: params[:id]).select('DISTINCT ON ("novel_id") *').order("novel_id, created_at DESC"),:reviews).order(created_at: :desc)
+    @reviews = Review.from(Review.where(comment: 'Review', user_id: params[:id]).select('DISTINCT ON ("novel_id") *').order("novel_id, created_at DESC"),:reviews).order(created_at: :desc)
     @narrow_reviews = @reviews.page(params[:review_page]).per(4)
   end
 

--- a/app/views/users/_user_reviews.html.erb
+++ b/app/views/users/_user_reviews.html.erb
@@ -2,7 +2,7 @@
   <div class="card-body">
     <h4 class="text-center"><%= link_to narrow_reviews.novel.title, novel_path(narrow_reviews.novel_id) %></h4>
     <ul class="list-inline justify-content-center">
-      <li class="list-inline-item mr-3"><%= link_to narrow_reviews.novel.user.name, user_path(narrow_reviews.user_id) %></li>
+      <li class="list-inline-item mr-3"><%= link_to narrow_reviews.novel.user.name, user_path(narrow_reviews.novel.user_id) %></li>
       <li class="list-inline-item mr-3"><%= narrow_reviews.novel.genre_i18n %></li>
       <li class="list-inline-item"><%= narrow_reviews.novel.story_length_i18n %></li>
     </ul>


### PR DESCRIPTION
## 概要

commentのデフォルトで入っている値を変えた時に、抽出要件を変えるのを忘れていたので修正。
また、批評した作品の作者名リンク定義も修正。