### PR TITLE
Fix:ユーザーからのFB２

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -7,6 +7,8 @@
 //= link novels/index.css
 //= link novels/form.css
 //= link reviews/reviews.css
+//= link reviews/review.css
+//= link reviews/reply.css
 //= link static_pages/about.css
 //= link static_pages/privacy.css
 //= link static_pages/rule.css

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,24 +1,17 @@
 .header {
   background: linear-gradient(-150deg, #05FBFF, #1E00FF);
 
-  .navbar-toggler {
-    background-color: aquamarine;
-    background-color: rgba(255, 255, 255,0.7);
-    width: 120px;
-    height: 50px;
-
     .navbar-toggler-icon {
       background-color: #1E00FF;
       opacity: 100%;
-      width: 90px;
-      height: 40px;
+      width: 110px;
+      height: 45px;
       color: white;
       border-radius: 5px;
       display: flex;
       justify-content: center;
       align-items: center;
     }
-  }
 }
 
 ul{

--- a/app/assets/stylesheets/reviews/reply.scss
+++ b/app/assets/stylesheets/reviews/reply.scss
@@ -1,0 +1,3 @@
+.reply-card {
+    background-color: rgb(206, 248, 206);
+}

--- a/app/assets/stylesheets/reviews/review.scss
+++ b/app/assets/stylesheets/reviews/review.scss
@@ -1,0 +1,3 @@
+.review-card {
+    background-color: rgb(206, 248, 206);
+}

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -32,7 +32,7 @@
       width: 18rem;
     }
     .background {
-      background-color: rgba(206, 248, 206, 0.5);
+      background-color: rgb(206, 248, 206);
       border-radius: 1rem;
       color: rgb(243, 126, 31);
       padding: 1rem;

--- a/app/javascript/trix-editor-overrides.js
+++ b/app/javascript/trix-editor-overrides.js
@@ -6,7 +6,7 @@ window.addEventListener("trix-file-accept", function(event) {
       alert("添付できる拡張子は、jpg、jpeg、pngのみです")
     }
     // 画像のbyte数をチェック
-    const maxFileSize = 2048 * 2048 // 1MB 
+    const maxFileSize = 2048 * 2048
     if (event.file.size > maxFileSize) {
       event.preventDefault()
       alert("アップできる画像は4MBまでです。")

--- a/app/models/novel.rb
+++ b/app/models/novel.rb
@@ -45,6 +45,6 @@ class Novel < ApplicationRecord
 
   def plot_required
     errors.add(:plot, I18n.t('defaults.message.nill_plot')) unless plot.body.present?
-    errors.add(:plot, I18n.t('defaults.message.over_plot')) unless ApplicationController.helpers.strip_tags(plot.to_s).gsub(/[\n]/,"").strip.length < 5001
+    errors.add(:plot, I18n.t('defaults.message.over_plot')) unless ApplicationController.helpers.strip_tags(plot.to_s).gsub(/[\n]/,"").strip.length < 8001
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
   </head>
 
-  <body style="margin-top:80px;" >
+  <body style="margin-top:80px; margin-bottom:80px;" >
 
     <% if logged_in? %>
       <%= render 'shared/header' %>

--- a/app/views/reviews/_reply.html.erb
+++ b/app/views/reviews/_reply.html.erb
@@ -1,5 +1,6 @@
+<%= stylesheet_link_tag "reviews/reply" %>
 <div id="js-reply-<%= reply.id %>">
-  <ul class="card m-3 p-3">
+  <ul class="card reply-card m-3 p-3">
     <li class="card-title">
       <%= link_to reply.user.name, user_path(reply.user) %>
       <% if current_user&.own?(reply) %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -1,3 +1,4 @@
+<%= stylesheet_link_tag "reviews/review" %>
 <tr id="review-<%= review.id %>">
   <% if !review.parent_id %>
     <td>
@@ -14,7 +15,7 @@
       <br>
       <br>
 
-      <div class="card card-body m-0 p-3" id="review-text-<%= review.id %>">
+      <div class="card review-card card-body m-0 p-3" id="review-text-<%= review.id %>">
         <ul class="m-0 p-0">
           <li class="list-inline-item">
             <%= t('activerecord.attributes.review.good_point') %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,13 +1,13 @@
-  <footer class="footer bg-info" style="height:80px" >
+  <footer class="footer fixed-bottom bg-info" style="height:80px" >
     <div class="container list-inline d-flex align-items-center" style="height:50px">
       <div class="mr-auto list-inline-item">
-        <%= link_to (t 'shared.footer.policy'), privacy_path, class:'text-white text-decoration-none' %>
+        <%= link_to (t 'shared.footer.policy'), privacy_path, class:'text-black text-decoration-none' %>
       </div>
       <div class="mx-auto list-inline-item">
-        <%= link_to (t 'shared.footer.rule'), rule_path, class:'text-white text-decoration-none' %>
+        <%= link_to (t 'shared.footer.rule'), rule_path, class:'text-black text-decoration-none' %>
       </div>
       <div class="ml-auto list-inline-item">
-        <%= link_to (t 'shared.footer.about_app'), about_path, class:'text-white text-decoration-none' %>
+        <%= link_to (t 'shared.footer.about_app'), about_path, class:'text-black text-decoration-none' %>
       </div>
     </div>
     <div class="d-flex justify-content-center"  style="height:30px">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,7 +9,7 @@
           <%= link_to (t 'defaults.edit'), edit_user_path(@user), class: 'btn btn-success edit-button' %>
         </div>
       <% end %>
-      <table class="table">
+      <table class="table" >
         <tr>
           <th scope="row"><%= t('activerecord.attributes.user.name') %></th>
           <td><%= @user.name %></td>

--- a/spec/models/novel_spec.rb
+++ b/spec/models/novel_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe Novel, type: :model do
     end
 
     it 'plot文字数超過' do
-      novel_over_plot = build(:novel, plot: "a" * 5001)
+      novel_over_plot = build(:novel, plot: "a" * 8001)
       expect(novel_over_plot).to be_invalid
-      expect(novel_over_plot.errors[:plot]).to eq ["は5000文字以内で入力してください"]
+      expect(novel_over_plot.errors[:plot]).to eq ["は8000文字以内で入力してください"]
     end
   end
 end

--- a/spec/system/novels_spec.rb
+++ b/spec/system/novels_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "Novels", type: :system do
           select '読み手まで', from: 'novel_release'
           fill_in_rich_text_area 'プロット', with: 'a' * 5001
           click_button '投稿する'
-          expect(page).to have_content 'プロットは5000文字以内で入力してください'
+          expect(page).to have_content 'プロットは8000文字以内で入力してください'
           expect(page).to have_content '小説を投稿できませんでした'
           expect(current_path).to eq novels_path
         end
@@ -235,7 +235,7 @@ RSpec.describe "Novels", type: :system do
           select '公開', from: 'novel_release'
           fill_in_rich_text_area 'プロット', with: 'a' * 5001
           click_button '更新する'
-          expect(page).to have_content 'プロットは5000文字以内で入力してください'
+          expect(page).to have_content 'プロットは8000文字以内で入力してください'
           expect(page).to have_content '小説を更新できませんでした'
           expect(current_path).to eq novel_path(novel)
         end


### PR DESCRIPTION
## 概要

小説詳細にて、小説と批評が分かりやすいよう色分け。
スマホ用メニューを修正。
トップページの透過を解除。
プロットを最大8000文字に。
フッターの文字色を黒、かつ下部固定に。