### PR TITLE
Fix:ドロップダウン修正

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -25,4 +25,7 @@ li {
   .notification {
     width: 100%;
   }
+  .dropdown-item {
+    text-align: center;
+  }
 }

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -7,5 +7,5 @@ class Review < ApplicationRecord
 
   validates :good_point, presence: true, length: { maximum: 1500 }
   validates :bad_point, length: { maximum: 1500 }
-  validates :comment, presence: true, length: { maximum: 1000 }
+  validates :comment, presence: true, length: { maximum: 1500 }
 end

--- a/app/views/reviews/_edit_form.html.erb
+++ b/app/views/reviews/_edit_form.html.erb
@@ -4,11 +4,11 @@
         <%= form_with model: [novel, review], id: 'js-new-review', local: false do |f| %>
           <div class="form-group">
             <%= f.label :good_point %>
-            <%= f.text_area :good_point, class: 'form-control edit-good', id: 'js-new-review-good_point', rows: 3 %>
+            <%= f.text_area :good_point, class: 'form-control edit-good', id: 'js-new-review-good_point js-text', rows: 3 %>
           </div>
           <div class="form-group">
             <%= f.label :bad_point %>
-            <%= f.text_area :bad_point, class: 'form-control edit-bad', id: 'js-new-review-bad_point', rows: 3 %>
+            <%= f.text_area :bad_point, class: 'form-control edit-bad', id: 'js-new-review-bad_point js-text', rows: 3 %>
           </div>
           <div class="form-group">
             <%= f.hidden_field :comment, class: 'form-control', value: 'Review' %>

--- a/app/views/reviews/_edit_form.html.erb
+++ b/app/views/reviews/_edit_form.html.erb
@@ -4,11 +4,11 @@
         <%= form_with model: [novel, review], id: 'js-new-review', local: false do |f| %>
           <div class="form-group">
             <%= f.label :good_point %>
-            <%= f.text_area :good_point, class: 'form-control edit-good', id: 'js-new-review-good_point js-text', rows: 3 %>
+            <%= f.text_area :good_point, class: 'form-control edit-good', id: 'js-new-review-good_point', rows: 3 %>
           </div>
           <div class="form-group">
             <%= f.label :bad_point %>
-            <%= f.text_area :bad_point, class: 'form-control edit-bad', id: 'js-new-review-bad_point js-text', rows: 3 %>
+            <%= f.text_area :bad_point, class: 'form-control edit-bad', id: 'js-new-review-bad_point', rows: 3 %>
           </div>
           <div class="form-group">
             <%= f.hidden_field :comment, class: 'form-control', value: 'Review' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -26,7 +26,7 @@
             href="#"role="button" data-bs-toggle="dropdown" aria-expanded="false">
             <%= t('shared.header.novel_menu') %>
           </a>
-          <ul class="dropdown-menu text-center" aria-labelledby="dropdownMenuLink">
+          <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
             <%= link_to (t 'novels.index.topic'), novels_path, class: 'dropdown-item' %>
             <% if current_user.role == "writer" %>
               <%= link_to (t 'shared.header.novel_post'), new_novel_path, class: 'dropdown-item' %>
@@ -34,12 +34,12 @@
           </ul>
         </li>
 
-        <li class="nav-item dropdown mr-4 m-2">
+        <li class="nav-item dropdown m-2">
           <a class="nav-link btn btn-secondary btn-lg dropdown-toggle bg-primary text-white" 
             href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               <%= current_user.name %>
           </a>
-          <ul class="dropdown-menu text-center" aria-labelledby="dropdownMenuLink">
+          <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
             <%= link_to (t 'users.show.topic'), user_path(current_user.id), class: 'dropdown-item' %>
             <% if current_user.admin == true %>
               <%= link_to (t 'defaults.admin'), admin_root_path, class: 'dropdown-item' %>

--- a/config/locales/activerecord/views/ja.yml
+++ b/config/locales/activerecord/views/ja.yml
@@ -78,7 +78,7 @@ ja:
       genre_select: 'ジャンルを選択'
       story_length_select: '文量を選択'
       releace_select: '公開範囲を選択'
-      plot_word: '5000文字以内で入力してください'
+      plot_word: '8000文字以内で入力してください'
       add_character: 'キャラクターの追加'
     character_fields:
       character_role_word: '20文字以内で入力してください'

--- a/spec/system/admin_reviews_spec.rb
+++ b/spec/system/admin_reviews_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "AdminReviews", type: :system do
                     visit edit_admin_review_path(reply)
                     fill_in '返信', with: 'r' * 1001
                     click_button '更新する'
-                    expect(page).to have_content '返信は1000文字以内で入力してください'
+                    expect(page).to have_content '返信は1500文字以内で入力してください'
                     expect(current_path).to eq admin_review_path(reply)
                 end
             end

--- a/spec/system/reviews_spec.rb
+++ b/spec/system/reviews_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Reviews", type: :system do
             click_link '返信'
             fill_in 'review[comment]', with: 'a' * 1001
             find('.reply-commit').click
-            expect(page).to have_content '返信は1000文字以内で入力してください'
+            expect(page).to have_content '返信は1500文字以内で入力してください'
             expect(current_path).to eq novel_path(novel)
           end
         end
@@ -183,7 +183,7 @@ RSpec.describe "Reviews", type: :system do
             find('.js-edit-reply-button').click
             fill_in 'review[comment]', with: 'a' * 1001
             find('.reply-commit').click
-            expect(page).to have_content '返信は1000文字以内で入力してください'
+            expect(page).to have_content '返信は1500文字以内で入力してください'
             expect(current_path).to eq novel_path(novel)
           end
         end


### PR DESCRIPTION
## 概要

スマホ版ドロップダウンを中央に。
返信の文字数を1500に。

文字数カウンターを実装しようとしたが、actiontext適用箇所だと正常に文字数をカウントできなかったので断念。